### PR TITLE
Ensure there is a response before redirect check

### DIFF
--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -523,8 +523,8 @@ WebHDFS.prototype.createWriteStream = function createWriteStream (path, append, 
   };
 
   var req = request(params, function (err, res, body) {
-    // Handle redirect
-    if (self._isRedirect(res)) {
+    // Handle redirect only if there was not an error (e.g. res is defined)
+    if (res && self._isRedirect(res)) {
       var upload = request(extend(params, { url: res.headers.location }), function (err, res, body) {
         if (err) {
           return req.emit('error', err);


### PR DESCRIPTION
I had some bad settings, and instead of emitting an error, it was throwing an error because `res` was `undefined` when checking for `statusCode`.
