### PR TITLE
Handling events for writing files before piping them as per instructi…

### DIFF
--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -409,8 +409,6 @@ WebHDFS.prototype.writeFile = function writeFile (path, data, append, opts, call
   var localStream = new BufferStreamReader(data);
   var remoteStream = this.createWriteStream(path, append, opts);
 
-  localStream.pipe(remoteStream); // Pipe data
-
   // Handle events
   remoteStream.on('error', function onError (err) {
     error = err;
@@ -419,6 +417,8 @@ WebHDFS.prototype.writeFile = function writeFile (path, data, append, opts, call
   remoteStream.on('finish', function onFinish () {
     return callback && callback(error);
   });
+
+  localStream.pipe(remoteStream); // Pipe data
 
   return remoteStream;
 };


### PR DESCRIPTION
…ons in the Request documentation.

https://www.npmjs.com/package/request#streaming
"To easily handle errors when streaming requests, listen to the error event before piping"