### PR TITLE
fix wrong permission prop name to match https://hadoop.apache.org/doc…

### DIFF
--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -291,7 +291,7 @@ WebHDFS.prototype.mkdir = function mkdir (path, mode, callback) {
   }
 
   var endpoint = this._getOperationEndpoint('mkdirs', path, {
-    permissions: mode || '0777'
+    permission: mode || 755
   });
 
   return this._sendRequest('PUT', endpoint, function (err) {
@@ -527,7 +527,7 @@ WebHDFS.prototype.createWriteStream = function createWriteStream (path, append, 
 
   var endpoint = this._getOperationEndpoint(append ? 'append' : 'create', path, extend({
     overwrite: true,
-    permissions: '0777'
+    permission: 755
   }, opts));
 
   var self = this;


### PR DESCRIPTION
in consideration of https://hadoop.apache.org/docs/r1.0.4/webhdfs.html#SETPERMISSION
the option property of file permission is "permission", not "permissions".