### PR TITLE
add timeout to fix front timeout

### DIFF
--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -32,7 +32,7 @@ function WebHDFS (opts, requestParams) {
   });
 
   this._requestParams = requestParams || {};
-  this._requestParams.timeout = requestParams.timeout || 10000;
+  this._requestParams.timeout = this._requestParams.timeout || 10000;
   this._opts = opts;
   this._url = {
     protocol: opts.protocol || 'http',

--- a/lib/webhdfs.js
+++ b/lib/webhdfs.js
@@ -31,7 +31,8 @@ function WebHDFS (opts, requestParams) {
     }
   });
 
-  this._requestParams = requestParams;
+  this._requestParams = requestParams || {};
+  this._requestParams.timeout = requestParams.timeout || 10000;
   this._opts = opts;
   this._url = {
     protocol: opts.protocol || 'http',


### PR DESCRIPTION
I found a problem on my side that caused the front-end timeout, and it took a long time for the end to report errors. It's hard to find out, and I think it's time to set a default timeout.